### PR TITLE
Split fonts based on languages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,7 @@ export default class App extends Vue {
       ? newLocale
       : this.$i18n.fallbackLocale;
     moment.locale(this.$i18n.locale);
-    root.setAttribute('class', `font-face-${this.getLocaleBasedFontFace(newLocale || this.$i18n.fallbackLocale)}`);
+    root.setAttribute('class', `font-face-${this.getLocaleBasedFontFace(this.$i18n.locale)}`);
   }
 
   @Watch('darkMode')

--- a/src/App.vue
+++ b/src/App.vue
@@ -56,10 +56,13 @@ export default class App extends Vue {
    */
   @Watch('locale')
   public localeChanged(newLocale: string | undefined) {
+    const root = document.getElementsByTagName('html')[0];
+
     this.$i18n.locale = newLocale && validLanguageCodes.includes(newLocale)
       ? newLocale
       : this.$i18n.fallbackLocale;
     moment.locale(this.$i18n.locale);
+    root.setAttribute('class', `font-face-${this.getLocaleBasedFontFace(newLocale || this.$i18n.fallbackLocale)}`);
   }
 
   @Watch('darkMode')
@@ -78,24 +81,44 @@ export default class App extends Vue {
       this.$i18n.locale = this.locale;
     }
 
+    const root = document.getElementsByTagName('html')[0];
+    root.setAttribute('class', `font-face-${this.getLocaleBasedFontFace(this.$i18n.locale)}`);
+
     this.$vuetify.theme.dark = appStore.darkMode;
 
     moment.locale(this.$i18n.locale);
   }
 
-  private async beforeMount() {
-    // await appStore.setLoadingState(true);
-
-    // if (aniListStore.isAuthenticated) {
-    //   await aniListStore.refreshAniListData();
-    //   await aniListStore.restartRefreshTimer();
-    // }
-
-    // await appStore.setLoadingState(false);
-  }
-
   private async beforeDestroy() {
     await aniListStore.destroyRefreshTimer();
+  }
+
+  private getLocaleBasedFontFace(locale: string): string {
+    let fontFace = '';
+
+    switch (locale) {
+      case 'ja': // Japanese
+        fontFace = 'ja';
+        break;
+      case 'zh_CN': // Chinese
+        fontFace = 'zh';
+        break;
+      case 'kr': // Korean
+        fontFace = 'kr';
+        break;
+      case 'ru': // Russian
+        fontFace = 'ru';
+        break;
+      case 'de':
+      case 'en':
+      case 'fr':
+      case 'pt_BR': // Latin-based
+      default:
+        fontFace = 'lt';
+        break;
+    }
+
+    return fontFace;
   }
 }
 </script>

--- a/src/assets/scss/fonts.scss
+++ b/src/assets/scss/fonts.scss
@@ -1,11 +1,4 @@
 @font-face {
-  font-family: "Noto Sans";
-  font-weight: bold;
-  font-style: normal;
-  src: url("../fonts/NotoSansCJKjp-Medium.otf") format("opentype");
-}
-
-@font-face {
   font-family: "Nutito";
   font-weight: normal;
   font-style: normal;
@@ -19,9 +12,65 @@
   src: url("../fonts/Nunito-SemiBold.ttf") format("truetype");
 }
 
-* {
+$default-typo: 'Nunito, Lato, Helvetica Neue, Helvetica, Arial, sans-serif';
+$japanese-default-typo: 'ヒラギノ角ゴ Pro W3, Hiragino Kaku Gothic Pro, Osaka, メイリオ, Meiryo, ＭＳ Ｐゴシック, MS PGothic';
+%font-face-lt {
+  font-family: unquote($default-typo), unquote($japanese-default-typo) !important;
+}
+%font-face-ar {
+  font-family: 'Geeza Pro', unquote($default-typo) !important;
+}
+%font-face-ru {
+  font-family: 'Charcoal', 'Geneva', unquote($default-typo) !important;
+}
+%font-face-ja {
+  font-family: unquote($japanese-default-typo), unquote($default-typo) !important;
+}
+%font-face-zh {
+  font-family: '华文细黑', 'STXihei', 'PingFang TC', '微软雅黑体', 'Microsoft YaHei New', '微软雅黑', 'Microsoft Yahei', '宋体', 'SimSun', unquote($default-typo) !important;
+}
+%font-face-kr {
+  font-family: 'Apple SD Gothic Neo', 'NanumBarunGothic', '맑은 고딕', 'Malgun Gothic', '굴림', 'Gulim', '돋움', 'Dotum', unquote($default-typo) !important;
+}
+
+html.font-face-lt * {
   &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
   &[class^='display-'] {
-    font-family: 'Nunito', Lato, 'Helvetica Neue', 'Hiragino Sans GB', 'SimHei', Arial, Helvetica, 'Noto Sans', sans-serif !important;
+    @extend %font-face-lt;
+  }
+}
+
+html.font-face-ar * {
+  &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
+  &[class^='display-'] {
+    @extend %font-face-ar;
+  }
+}
+
+html.font-face-ru * {
+  &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
+  &[class^='display-'] {
+    @extend %font-face-ru;
+  }
+}
+
+html.font-face-ja * {
+  &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
+  &[class^='display-'] {
+    @extend %font-face-ja;
+  }
+}
+
+html.font-face-zh * {
+  &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
+  &[class^='display-'] {
+    @extend %font-face-zh;
+  }
+}
+
+html.font-face-kr * {
+  &:not(.fas):not(.far):not(.icon):not(.fab):not(.fa):not(.mdi):not(.v-progress-circular__info),
+  &[class^='display-'] {
+    @extend %font-face-kr;
   }
 }


### PR DESCRIPTION
For future possible translations, Korean, Russian and Arabic
font definitions are already implemented
and only need their locale and addition to the App.vue
for the font-face class switch.

Fixes #104 