### PR TITLE
Fix icons and navigation drawer position

### DIFF
--- a/src/assets/scss/extra.scss
+++ b/src/assets/scss/extra.scss
@@ -7,3 +7,14 @@
 ::-webkit-scrollbar {
   display: none;
 }
+
+#app.v-application--is-rtl .v-icon {
+  &:not(.mdi-play):not(.mdi-check) {
+    -moz-transform: scaleX(-1);
+    -o-transform: scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
+    filter: FlipH;
+    -ms-filter: "FlipH";
+  }
+}

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -9,6 +9,7 @@
       v-model="navigationDrawer"
       temporary
       app
+      :right="$vuetify.rtl"
     >
       <v-list-item>
         <v-list-item-content>


### PR DESCRIPTION
Fix the positioning of the navigation drawer when RTL is active.
Also flip the icons except the play and checkmark when RTL is active.