### PR TITLE
Fix several points in season preview

### DIFF
--- a/src/components/AniList/SeasonPreview/AddButton.vue
+++ b/src/components/AniList/SeasonPreview/AddButton.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-btn
+    v-if="inList || isAdded"
+    block
+    text
+    color="grey"
+  >
+    <v-icon left color="info">
+      mdi-check
+    </v-icon>
+    {{ $t('actions.added') }}
+  </v-btn>
+  <v-btn
+    v-else
+    block
+    text
+    :disabled="isLocked"
+    :loading="isLoading"
+    @click="addMediaToPlanList(item)"
+  >
+    <v-icon left color="success">
+      mdi-playlist-plus
+    </v-icon>
+    {{ $t('actions.addToPlanToWatch') }}
+  </v-btn>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { AniListListStatus } from '@/modules/AniList/types';
+import AniListAPI from '@/modules/AniList/API';
+import { userStore, appStore } from '@/store';
+
+@Component
+export default class SeasonPreviewAddButton extends Vue {
+  @Prop() item!: any;
+
+  isLoading: boolean = false;
+
+  isAdded: boolean = false;
+
+  get inList(): boolean {
+    return this.item.inList;
+  }
+
+  get isLocked(): boolean {
+    return this.item.isLocked;
+  }
+
+  async addMediaToPlanList(item: any): Promise<void> {
+    await appStore.setLoadingState(true);
+    this.isLoading = true;
+
+    try {
+      const response = await AniListAPI.addEntry(item.id, AniListListStatus.PLANNING);
+
+      if (response) {
+        this.isAdded = true;
+
+        // We don't want to reload everytime a media is added to planned list
+        // so we just set the refresh timer to half a minute, which is enough time
+        // to think about adding another anime to the planned list which then resets the timer again
+        const tempRefreshRate = userStore.refreshRate;
+        await userStore.setRefreshRate(0.5);
+        await userStore.restartRefreshTimer();
+        await userStore.setRefreshRate(tempRefreshRate);
+      }
+    } catch (error) {
+      //
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    this.isLoading = false;
+    await appStore.setLoadingState(false);
+  }
+}
+</script>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -84,7 +84,7 @@
       <LoadingIndicator />
 
       <BackButton v-if="$vuetify.breakpoint.mdAndUp" />
-      <SortButton />
+      <SortButton v-if="isSortingPage" />
       <SearchButton v-if="isAuthenticated" />
 
       <AniListRefresh />
@@ -192,6 +192,10 @@ export default class Navigation extends Vue {
 
   private get isSeasonPreviewPage(): boolean {
     return this.$route.meta && this.$route.meta.seasonPreviewPage;
+  }
+
+  private get isSortingPage(): boolean {
+    return this.$route.meta && this.$route.meta.sortingPage;
   }
 
   private get currentRouteName(): string {

--- a/src/components/NavigationToolbars/Items/Sort.vue
+++ b/src/components/NavigationToolbars/Items/Sort.vue
@@ -3,12 +3,12 @@
     v-model="sortMenu"
     :close-on-content-click="false"
     offset-y
+    absolute
   >
     <template v-slot:activator="{ on: sortWindow }">
       <v-tooltip bottom>
         <template v-slot:activator="{ on: toolTip }">
           <v-btn
-            v-if="isSortingPage"
             text
             icon
             v-on="{ ...toolTip, ...sortWindow }"
@@ -35,6 +35,18 @@
             <v-radio-group v-model="direction" column @change="changeDirection">
               <v-radio :label="$t('components.sorting.directions.ascending')" value="asc" />
               <v-radio :label="$t('components.sorting.directions.descending')" value="desc" />
+            </v-radio-group>
+          </v-flex>
+          <v-flex xs12>
+            <v-radio-group
+              v-model="adultContent"
+              :label="$t('pages.search.adultContent.label')"
+              column
+              @change="changeAdultContent"
+            >
+              <v-radio :label="$t('pages.search.adultContent.both')" value="noFilter" />
+              <v-radio :label="$t('pages.search.adultContent.onlyAdult')" value="only" />
+              <v-radio :label="$t('pages.search.adultContent.onlyNonAdult')" value="without" />
             </v-radio-group>
           </v-flex>
         </v-layout>
@@ -109,6 +121,8 @@ export default class Sort extends Vue {
   private direction: string = 'asc';
 
   private sortItem: string = 'title';
+
+  adultContent: string = 'without';
 
   private created() {
     EventBus.$on('resetAllSorts', () => {
@@ -190,14 +204,22 @@ export default class Sort extends Vue {
     });
   }
 
+  changeAdultContent(value: string) {
+    EventBus.$emit('changeAdultContentFilter', {
+      adultFilter: value,
+    });
+  }
+
   private resetFilters(emitEvents: boolean = true): void {
     this.genreValues = [];
     this.sortItem = 'title';
     this.direction = 'asc';
+    this.adultContent = 'without';
 
     if (emitEvents) {
       this.changeGenres(this.genreValues);
       this.changeSorting(this.sortItem);
+      this.changeAdultContent(this.adultContent);
       // Direction is automatically send with sorting
     }
   }

--- a/src/modules/AniList/API/index.ts
+++ b/src/modules/AniList/API/index.ts
@@ -112,22 +112,40 @@ export default class AniListAPI {
     return null;
   }
 
-  public static async getSeasonPreview(seasonYear: number, season: AniListSeason): Promise<IAniListSeasonPreview | null> {
-    try {
-      const response = await axios.post('/', {
-        query: getSeasonPreview,
-        variables: {
-          season,
-          seasonYear,
-        },
-      });
+  public static async getSeasonPreview(seasonYear: number, season: AniListSeason, accessToken: string): Promise<IAniListSeasonPreview | null> {
+    const headers = { Authorization: `Bearer ${accessToken}` };
 
-      const { media } = response.data.data.page;
+    try {
+      const mediaItems: IAniListSeasonPreviewMedia[] = [];
+      let page = 1;
+      let tmp = true;
+
+      while (tmp) {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await axios.post('/', {
+          query: getSeasonPreview,
+          variables: {
+            season,
+            seasonYear,
+            page,
+          },
+        }, { headers });
+
+        const { media } = response.data.data.page;
+
+        if (!media.length) {
+          tmp = false;
+          break;
+        }
+
+        mediaItems.push(...media);
+        page += 1;
+      }
 
       return {
         season,
         seasonYear,
-        media,
+        media: mediaItems,
       };
     } catch (error) {
       //

--- a/src/modules/AniList/API/queries/getSeasonPreview.graphql.ts
+++ b/src/modules/AniList/API/queries/getSeasonPreview.graphql.ts
@@ -1,6 +1,6 @@
 export default `
-query getSeasonAnime($seasonYear: Int, $season: MediaSeason) {
-  page: Page {
+query getSeasonAnime($seasonYear: Int, $season: MediaSeason, $page: Int) {
+  page: Page(page: $page) {
     media(season: $season, seasonYear: $seasonYear, type: ANIME) {
       id
       title {

--- a/src/store/UserSettings.ts
+++ b/src/store/UserSettings.ts
@@ -73,6 +73,11 @@ export class UserSettings extends VuexModule {
     return this._session;
   }
 
+  @getter
+  public get accessToken(): string {
+    return this._session.accessToken;
+  }
+
   /**
    * @getter
    * @method isAuthenticated


### PR DESCRIPTION
Send access token to use logged in state
Fix loading animation on add buttons
Fix fetch method that normally limits to 50
Add adult content filter
Temporarily fix v-menu of sorting

The temporary fix is due to Vuetify having a bug
in their v-menu script that causes activators
with tooltips to let the menu appear in
a corner instead of the mouse position.
Until that bug is fixed in a future vuetify
version, this temporary fix will stay.

Related: #148 #151 #152 #153 #154
Fixes #148 
Fixes #151 
Fixes #152 
Fixes #153 
Fixes #154